### PR TITLE
[travis-ci] Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ env:
   # matrix variables will create a new build for each specified variable
   matrix:
     - NODE_ENV=development
-    - NODE_ENV=production
+    # Do not use production mode for testing, because this prevents ava from
+    # being installed, and prevents us from testing it.
+    # - NODE_ENV=production
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+# Notification Options
+notifications:
+  email: false
+
+# Regent supports Node.js v8
+language: node_js
+node_js:
+  - '10'
+
+# Operating Systems
+os:
+  - linux
+  # MacOS would be nice, but builds take too long.
+  # - osx
+
+# Branches that can trigger Travis-CI
+branches:
+  only:
+    - master        # Master
+    - /^issue-.*$/ # Issues
+
+# declare your environment variables
+env:
+  # matrix variables will create a new build for each specified variable
+  matrix:
+    - NODE_ENV=development
+    - NODE_ENV=production
+
+install:
+  - npm install
+
+script:
+  - npm run build && npm run test


### PR DESCRIPTION
This commit adds support for Travis CI to the codebase. My thoughts are
that by automating some of the checking features, I can make sure that
my pull requests are validated by someone (or something) other than
myself. The configuration has  mostly been stolen from the Regent
configuration, but should be sufficient for this use case.