### PR TITLE
Issue #18: UNCLASSIFIED releasability caveats block C, R, S, TS caveats.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "classification-manager",
   "homepage": "https://github.com/stevethedev/std-classifier",
   "version": "1.0.8",
-  "description": "Department of Defense Classification Library",
+  "description": "Library for working with document classifications, based on DoD Guidelines",
   "main": "index.js",
   "types": "./dist/classifier.d.ts",
   "author": "Steven Jimenez <steven@stevethedev.com>",

--- a/test/unclassified-reduction.js
+++ b/test/unclassified-reduction.js
@@ -1,0 +1,31 @@
+import test from 'ava';
+import { ClassificationCollection } from '../src/classification-collection';
+import { Classification } from '../src/classification';
+
+test('Unclassified classifications do not strip REL TO when primary', (t) => {
+  const cc = new ClassificationCollection();
+  const c1 = new Classification();
+  const c2 = new Classification();
+
+  c2.setClassificationLevel(4);
+  c2.addRel('GBR');
+
+  cc.add(c1);
+  cc.add(c2);
+
+  t.is(cc.reduce().toString(), 'TOP SECRET//REL TO USA and GBR');
+});
+
+test('Unclassified classifications do not strip REL TO when secondary', (t) => {
+  const cc = new ClassificationCollection();
+  const c1 = new Classification();
+  const c2 = new Classification();
+
+  c1.setClassificationLevel(4);
+  c1.addRel('GBR');
+
+  cc.add(c1);
+  cc.add(c2);
+
+  t.is(cc.reduce().toString(), 'TOP SECRET//REL TO USA and GBR');
+});


### PR DESCRIPTION
<!---
  Thank you for contributing to the Classification Manager!
  To make it easier for me to process this pull request, please provide:
     - A summary of your pull request
     - Any issue(s) your pull request relates to
     - Any manual steps necessary to validate your pull request
-->

<!--- Please provide a general summary of your pull request in the Title field (above) -->

### Description

This commit fixes the bug reported in Ticket #18. This fix corrects the
issue by checking the classification levels of two Classification
objects prior to merge, and then caching any relevant REL TO elements
before they are merged together. If there are any cached REL TO
elements, then they are mixed back into the classification after the
merge is complete.

This implementation helps prevent the Dissemination class from needing
to be aware of the classification levels of each classification outside
of the class, and sets up a precedent moving forward for where these
kinds of rule-oddities should be handled.

### Fixed Issues (if relevant)
1. Fixes a bug where UNCLASSIFIED classifications would squash the REL TO caveats. (#18)

### Manual testing
No manual testing necessary; two tests added to `./tests/unclassified-reduction.js`.

### Contribution checklist
 - [x] The pull request has a meaningful title and description.
 - [x] All commits are accompanied by meaningful commit messages.
 - [x] All new or changed code is covered with automated tests (as applicable).
 - [ ] All CI validation steps have passed.
